### PR TITLE
change tw image max height and width setting

### DIFF
--- a/lib/uv_media_validator/tw_image.rb
+++ b/lib/uv_media_validator/tw_image.rb
@@ -11,8 +11,8 @@ module UvMediaValidator
 
     MIN_WIDTH = 4
     MIN_HEIGHT = 4
-    MAX_WIDTH = 8192
-    MAX_HEIGHT = 8192
+    MAX_WIDTH = 2048
+    MAX_HEIGHT = 2048
     FORMAT_ARRAY = %i(jpeg png gif webp)
 
     def initialize(path, info: nil)


### PR DESCRIPTION
twitter api で投稿に対して添付できる画像の最大値が変更になっていたようなので、修正しました。<br>

```
Image dimensions must be >= 4x4 and <= 2048x2048
```