### PR TITLE
再度 Instagramの動画検証で HEVC(H.265) コーデックを有効にする

### DIFF
--- a/lib/uv_media_validator/ig_video.rb
+++ b/lib/uv_media_validator/ig_video.rb
@@ -10,7 +10,7 @@ module UvMediaValidator
     AUDIO_CODEC = 'aac'
     MAX_AUDIO_SAMPLE_RATE = 48 * 1024
     MAX_AUDIO_CHANNELS = 2
-    VIDEO_CODEC_ARRAY = ['h264']
+    VIDEO_CODEC_ARRAY = ['hevc', 'h264']
     MIN_FRAME_RATE = 23
     MAX_FRAME_RATE = 60
     MIN_ASPECT_RATIO = 4.fdiv(5)

--- a/spec/uv_media_validator_ig_spec.rb
+++ b/spec/uv_media_validator_ig_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe UvMediaValidator do
     expect(media.audio_codec?).to eq(true)
     expect(media.audio_sample_rate?).to eq(false)
     expect(media.audio_channels?).to eq(false)
-    expect(media.video_codec?).to eq(false)
+    expect(media.video_codec?).to eq(true)
     expect(media.video_bitrate?).to eq(true)
   end
 


### PR DESCRIPTION
再度詳しい調査をした結果、InstagramのAPIでHEVCが扱えないわけではなく、検証に使った動画の別のスペックがダメでした。そのため再度有効にします。