### PR TITLE
IGリール投稿用のメディア検証クラスを追加

### DIFF
--- a/lib/uv_media_validator.rb
+++ b/lib/uv_media_validator.rb
@@ -54,9 +54,9 @@ module UvMediaValidator
     return IgImage.new(path, max_image_bytes: max_image_bytes, info: image_size) unless image_size.format.nil?
 
     movie = FFMPEG::Movie.new(path)
-    video_class = reel_flag ? IgReel : IgVideo
-    return video_class.new(path, sync_flag: sync_flag, info: movie) if movie.valid?
+    return nil unless movie.valid?
 
-    nil
+    video_class = reel_flag ? IgReel : IgVideo
+    video_class.new(path, sync_flag: sync_flag, info: movie)
   end
 end

--- a/lib/uv_media_validator.rb
+++ b/lib/uv_media_validator.rb
@@ -46,17 +46,17 @@ module UvMediaValidator
     end
   end
 
-  def self.get_ig_validator(path, sync_flag: true, max_image_bytes: nil)
+  def self.get_ig_validator(path, sync_flag: true, max_image_bytes: nil, reel_flag: false)
     image_size = ImageSize.path(path)
-    if image_size.format.nil?
-      movie = FFMPEG::Movie.new(path)
-      if movie.valid?
-        return IgVideo.new(path, sync_flag: sync_flag, info: movie)
-      else
-        return nil
-      end
-    else
-      return IgImage.new(path, max_image_bytes: max_image_bytes, info: image_size)
-    end
+    # リールは動画のみ
+    return nil if !image_size.format.nil? && reel_flag
+
+    return IgImage.new(path, max_image_bytes: max_image_bytes, info: image_size) unless image_size.format.nil?
+
+    movie = FFMPEG::Movie.new(path)
+    video_class = reel_flag ? IgReel : IgVideo
+    return video_class.new(path, sync_flag: sync_flag, info: movie) if movie.valid?
+
+    nil
   end
 end

--- a/lib/uv_media_validator/ig_video.rb
+++ b/lib/uv_media_validator/ig_video.rb
@@ -111,4 +111,12 @@ module UvMediaValidator
       video_bitrate?
     end
   end
+
+  class IgReel < IgVideo
+    MIN_ASPECT_RATIO = 0.01.fdiv(1)
+    MAX_ASPECT_RATIO = 10.fdiv(1)
+    MAX_DURATION = 60 * 15
+    MIN_DURATION = 3
+    MAX_SIZE = 1024 * 1024 * 1024 # Bytes
+  end
 end

--- a/lib/uv_media_validator/ig_video.rb
+++ b/lib/uv_media_validator/ig_video.rb
@@ -1,7 +1,6 @@
 require 'image_size'
 
 module UvMediaValidator
-
   class IgVideo
     include UvMediaValidator::Validator::FileSize
     include UvMediaValidator::Validator::ViewSize
@@ -29,7 +28,7 @@ module UvMediaValidator
     end
 
     def max_size
-      MAX_SIZE
+      self.class::MAX_SIZE
     end
 
     def video_info
@@ -41,7 +40,7 @@ module UvMediaValidator
     end
 
     def duration?
-      (MIN_DURATION..MAX_DURATION).include?(video_info.duration)
+      (self.class::MIN_DURATION..self.class::MAX_DURATION).include?(video_info.duration)
     end
 
     def width
@@ -53,18 +52,18 @@ module UvMediaValidator
     end
 
     def aspect_ratio?
-      (MIN_ASPECT_RATIO..MAX_ASPECT_RATIO).include?(width.fdiv(height))
+      (self.class::MIN_ASPECT_RATIO..self.class::MAX_ASPECT_RATIO).include?(width.fdiv(height))
     end
 
     def format?
-      FORMAT_ARRAY.include?(File.extname(@path).gsub(/\./, '').downcase.to_sym)
+      self.class::FORMAT_ARRAY.include?(File.extname(@path).gsub(/\./, '').downcase.to_sym)
     end
 
     def audio_codec?
       if video_info.audio_codec.nil?
         false
       else
-        video_info.audio_codec == AUDIO_CODEC
+        video_info.audio_codec == self.class::AUDIO_CODEC
       end
     end
 
@@ -72,7 +71,7 @@ module UvMediaValidator
       if video_info.audio_sample_rate.nil?
         false
       else
-        video_info.audio_sample_rate <= MAX_AUDIO_SAMPLE_RATE
+        video_info.audio_sample_rate <= self.class::MAX_AUDIO_SAMPLE_RATE
       end
     end
 
@@ -80,20 +79,20 @@ module UvMediaValidator
       if video_info.audio_channels.nil?
         false
       else
-        video_info.audio_channels <= MAX_AUDIO_CHANNELS
+        video_info.audio_channels <= self.class::MAX_AUDIO_CHANNELS
       end
     end
 
     def video_codec?
-      VIDEO_CODEC_ARRAY.include?(video_info.video_codec)
+      self.class::VIDEO_CODEC_ARRAY.include?(video_info.video_codec)
     end
 
     def video_bitrate?
-      video_info.video_bitrate <= MAX_VIDEO_BITRATE
+      video_info.video_bitrate <= self.class::MAX_VIDEO_BITRATE
     end
 
     def frame_rate_range?
-      (MIN_FRAME_RATE..MAX_FRAME_RATE).include?(video_info.frame_rate)
+      (self.class::MIN_FRAME_RATE..self.class::MAX_FRAME_RATE).include?(video_info.frame_rate)
     end
 
     def all?

--- a/spec/uv_media_validator_fb_spec.rb
+++ b/spec/uv_media_validator_fb_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UvMediaValidator do
+RSpec.describe 'Facebook' do
   it "has a version number" do
     expect(UvMediaValidator::VERSION).not_to be nil
   end

--- a/spec/uv_media_validator_ig_spec.rb
+++ b/spec/uv_media_validator_ig_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UvMediaValidator do
+RSpec.describe 'Instagram' do
   it "has a version number" do
     expect(UvMediaValidator::VERSION).not_to be nil
   end

--- a/spec/uv_media_validator_ig_spec.rb
+++ b/spec/uv_media_validator_ig_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe UvMediaValidator do
     media = UvMediaValidator.get_ig_validator("test/ig_images/700x700.jpeg")
     expect(media.class.name).to eq("UvMediaValidator::IgImage")
     expect(media.all?).to eq(true)
+
+    media = UvMediaValidator.get_ig_validator("test/ig_images/700x700.jpeg", reel_flag: true)
+    expect(media).to eq(nil)
+
+    media = UvMediaValidator.get_ig_validator("test/ig_videos/30fps_44100Hz_640x480.mp4", reel_flag: true)
+    expect(media.class.name).to eq("UvMediaValidator::IgReel")
+    expect(media.all?).to eq(true)
   end
 
   it "ig image wrong aspect ratio (1 : 2) and wrong format" do
@@ -200,5 +207,119 @@ RSpec.describe UvMediaValidator do
     expect(media.frame_rate_range?).to eq(true)
     expect(media.video_codec?).to eq(true)
     expect(media.video_bitrate?).to eq(true)
+  end
+
+  describe "Reel" do
+    it "ig video short duration" do
+      media = UvMediaValidator::IgReel.new("test/ig_videos/1.8s.mp4")
+      expect(media.file_size?).to eq(true)
+      expect(media.duration?).to eq(false)
+      expect(media.max_height?).to eq(true)
+      expect(media.max_width?).to eq(true)
+      expect(media.aspect_ratio?).to eq(true)
+      expect(media.format?).to eq(true)
+      expect(media.frame_rate_range?).to eq(true)
+      expect(media.audio_codec?).to eq(true)
+      expect(media.audio_sample_rate?).to eq(true)
+      expect(media.audio_channels?).to eq(true)
+      expect(media.video_codec?).to eq(true)
+      expect(media.video_bitrate?).to eq(true)
+    end
+
+    it "ig video normal duration" do
+      media = UvMediaValidator::IgReel.new("test/ig_videos/78s.mp4")
+      expect(media.file_size?).to eq(true)
+      expect(media.duration?).to eq(true)
+      expect(media.max_height?).to eq(true)
+      expect(media.max_width?).to eq(true)
+      expect(media.aspect_ratio?).to eq(true)
+      expect(media.format?).to eq(true)
+      expect(media.frame_rate_range?).to eq(true)
+      expect(media.audio_codec?).to eq(true)
+      expect(media.audio_sample_rate?).to eq(true)
+      expect(media.audio_channels?).to eq(true)
+      expect(media.video_codec?).to eq(true)
+      expect(media.video_bitrate?).to eq(true)
+    end
+
+    it "ig video less fps" do
+      media = UvMediaValidator::IgReel.new("test/ig_videos/15fps.mp4")
+      expect(media.file_size?).to eq(true)
+      expect(media.duration?).to eq(true)
+      expect(media.max_height?).to eq(true)
+      expect(media.max_width?).to eq(true)
+      expect(media.aspect_ratio?).to eq(true)
+      expect(media.format?).to eq(true)
+      expect(media.frame_rate_range?).to eq(false)
+      expect(media.audio_codec?).to eq(true)
+      expect(media.audio_sample_rate?).to eq(true)
+      expect(media.audio_channels?).to eq(true)
+      expect(media.video_codec?).to eq(true)
+      expect(media.video_bitrate?).to eq(true)
+    end
+
+    it "ig video valid aspect ratio (1 : 2)" do
+      media = UvMediaValidator::IgReel.new("test/ig_videos/200x400.mp4")
+      expect(media.file_size?).to eq(true)
+      expect(media.duration?).to eq(true)
+      expect(media.max_height?).to eq(true)
+      expect(media.max_width?).to eq(true)
+      expect(media.aspect_ratio?).to eq(false)
+      expect(media.format?).to eq(true)
+      expect(media.frame_rate_range?).to eq(true)
+      expect(media.audio_codec?).to eq(true)
+      expect(media.audio_sample_rate?).to eq(true)
+      expect(media.audio_channels?).to eq(true)
+      expect(media.video_codec?).to eq(true)
+      expect(media.video_bitrate?).to eq(true)
+    end
+
+    it "ig video valid aspect ratio (2 : 1)" do
+      media = UvMediaValidator::IgReel.new("test/ig_videos/400x200.mp4")
+      expect(media.file_size?).to eq(true)
+      expect(media.duration?).to eq(true)
+      expect(media.max_height?).to eq(true)
+      expect(media.max_width?).to eq(true)
+      expect(media.aspect_ratio?).to eq(true)
+      expect(media.format?).to eq(true)
+      expect(media.frame_rate_range?).to eq(true)
+      expect(media.audio_codec?).to eq(true)
+      expect(media.audio_sample_rate?).to eq(true)
+      expect(media.audio_channels?).to eq(true)
+      expect(media.video_codec?).to eq(true)
+      expect(media.video_bitrate?).to eq(true)
+    end
+
+    it "ig video too high spec" do
+      media = UvMediaValidator::IgReel.new("test/ig_videos/8K-120fps-96kHz-6channels.mp4")
+      expect(media.file_size?).to eq(true)
+      expect(media.duration?).to eq(true)
+      expect(media.max_height?).to eq(false)
+      expect(media.max_width?).to eq(false)
+      expect(media.aspect_ratio?).to eq(true)
+      expect(media.format?).to eq(true)
+      expect(media.frame_rate_range?).to eq(false)
+      expect(media.audio_codec?).to eq(true)
+      expect(media.audio_sample_rate?).to eq(false)
+      expect(media.audio_channels?).to eq(false)
+      expect(media.video_codec?).to eq(true)
+      expect(media.video_bitrate?).to eq(true)
+    end
+
+    it "ig video high bitrate" do
+      media = UvMediaValidator::IgReel.new("test/ig_videos/8Mbps_1920x1080.mp4")
+      expect(media.file_size?).to eq(true)
+      expect(media.duration?).to eq(true)
+      expect(media.max_height?).to eq(true)
+      expect(media.max_width?).to eq(true)
+      expect(media.aspect_ratio?).to eq(true)
+      expect(media.format?).to eq(true)
+      expect(media.frame_rate_range?).to eq(true)
+      expect(media.audio_codec?).to eq(true)
+      expect(media.audio_sample_rate?).to eq(true)
+      expect(media.audio_channels?).to eq(true)
+      expect(media.video_codec?).to eq(true)
+      expect(media.video_bitrate?).to eq(true)
+    end
   end
 end

--- a/spec/uv_media_validator_ig_spec.rb
+++ b/spec/uv_media_validator_ig_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe UvMediaValidator do
       expect(media.duration?).to eq(true)
       expect(media.max_height?).to eq(true)
       expect(media.max_width?).to eq(true)
-      expect(media.aspect_ratio?).to eq(false)
+      expect(media.aspect_ratio?).to eq(true)
       expect(media.format?).to eq(true)
       expect(media.frame_rate_range?).to eq(true)
       expect(media.audio_codec?).to eq(true)

--- a/spec/uv_media_validator_tw_spec.rb
+++ b/spec/uv_media_validator_tw_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UvMediaValidator do
+RSpec.describe 'Twitter' do
   it "has a version number" do
     expect(UvMediaValidator::VERSION).not_to be nil
   end


### PR DESCRIPTION
Instagramリール投稿に対応するため、IgReelクラスを追加しました。
ベースはVideoクラスで細かい要求スペックが異なるため、定数の上書きによって対応しています。定数の場合単純にオーバーライドはできず、それを実現するため、既存のコードで参照している部分は少し修正をいれています。

また、Instagramのメディアクラスを取得する `get_ig_validator` もフラグの切り替えによりリールに対応しています。

Specを追加してすべてGreenであることは確認ずみです。