### PR TITLE
Instagramストーリーズに関するクラスを追加

### DIFF
--- a/lib/uv_media_validator.rb
+++ b/lib/uv_media_validator.rb
@@ -46,17 +46,36 @@ module UvMediaValidator
     end
   end
 
-  def self.get_ig_validator(path, sync_flag: true, max_image_bytes: nil, reel_flag: false)
+  def self.get_ig_feed_validator(path, sync_flag: true, max_image_bytes: nil)
     image_size = ImageSize.path(path)
-    # リールは動画のみ
-    return nil if !image_size.format.nil? && reel_flag
 
     return IgImage.new(path, max_image_bytes: max_image_bytes, info: image_size) unless image_size.format.nil?
 
     movie = FFMPEG::Movie.new(path)
     return nil unless movie.valid?
 
-    video_class = reel_flag ? IgReel : IgVideo
-    video_class.new(path, sync_flag: sync_flag, info: movie)
+    IgVideo.new(path, sync_flag: sync_flag, info: movie)
+  end
+
+  def self.get_ig_reel_validator(path, sync_flag: true)
+    image_size = ImageSize.path(path)
+
+    # リールは動画のみ
+    return nil unless image_size.format.nil?
+
+    movie = FFMPEG::Movie.new(path)
+    return nil unless movie.valid?
+
+    IgReel.new(path, sync_flag: sync_flag, info: movie)
+  end
+
+  def self.get_ig_stories_validator(path, sync_flag: true, max_image_bytes: nil)
+    image_size = ImageSize.path(path)
+    return IgStoriesImage.new(path, max_image_bytes: max_image_bytes, info: image_size) unless image_size.format.nil?
+
+    movie = FFMPEG::Movie.new(path)
+    return nil unless movie.valid?
+
+    IgStoriesVideo.new(path, sync_flag: sync_flag, info: movie)
   end
 end

--- a/lib/uv_media_validator/ig_image.rb
+++ b/lib/uv_media_validator/ig_image.rb
@@ -58,4 +58,32 @@ module UvMediaValidator
       file_size? && max_height? && max_width? && aspect_ratio? && format?
     end
   end
+
+  # For Instagram stories image
+  class IgStoriesImage < IgImage
+    # There are no restrictions on aspect ratio.
+    def aspect_ratio?
+      # Set image info to self instance
+      height
+      width
+
+      true
+    end
+
+    # There are no restrictions on height.
+    def max_height?
+      # Set image info to self instance
+      height
+
+      true
+    end
+
+    # There are no restrictions on width.
+    def max_width?
+      # Set image info to self instance
+      width
+
+      true
+    end
+  end
 end

--- a/lib/uv_media_validator/ig_video.rb
+++ b/lib/uv_media_validator/ig_video.rb
@@ -118,4 +118,10 @@ module UvMediaValidator
     MIN_DURATION = 3
     MAX_SIZE = 1024 * 1024 * 1024 # Bytes
   end
+
+  # For Instagram stories video
+  class IgStoriesVideo < IgVideo
+    MIN_ASPECT_RATIO = 0.01.fdiv(1)
+    MAX_ASPECT_RATIO = 10.fdiv(1)
+  end
 end

--- a/spec/uv_media_validator_ig_spec.rb
+++ b/spec/uv_media_validator_ig_spec.rb
@@ -4,19 +4,27 @@ RSpec.describe 'Instagram' do
   end
 
   it "get_ig_validator" do
-    media = UvMediaValidator.get_ig_validator("test/ig_videos/30fps_44100Hz_640x480.mp4")
+    media = UvMediaValidator.get_ig_feed_validator("test/ig_videos/30fps_44100Hz_640x480.mp4")
     expect(media.class.name).to eq("UvMediaValidator::IgVideo")
     expect(media.all?).to eq(true)
 
-    media = UvMediaValidator.get_ig_validator("test/ig_images/700x700.jpeg")
+    media = UvMediaValidator.get_ig_feed_validator("test/ig_images/700x700.jpeg")
     expect(media.class.name).to eq("UvMediaValidator::IgImage")
     expect(media.all?).to eq(true)
 
-    media = UvMediaValidator.get_ig_validator("test/ig_images/700x700.jpeg", reel_flag: true)
+    media = UvMediaValidator.get_ig_reel_validator("test/ig_images/700x700.jpeg")
     expect(media).to eq(nil)
 
-    media = UvMediaValidator.get_ig_validator("test/ig_videos/30fps_44100Hz_640x480.mp4", reel_flag: true)
+    media = UvMediaValidator.get_ig_reel_validator("test/ig_videos/30fps_44100Hz_640x480.mp4")
     expect(media.class.name).to eq("UvMediaValidator::IgReel")
+    expect(media.all?).to eq(true)
+
+    media = UvMediaValidator.get_ig_stories_validator("test/ig_videos/30fps_44100Hz_640x480.mp4")
+    expect(media.class.name).to eq("UvMediaValidator::IgStoriesVideo")
+    expect(media.all?).to eq(true)
+
+    media = UvMediaValidator.get_ig_stories_validator("test/ig_images/700x700.jpeg")
+    expect(media.class.name).to eq("UvMediaValidator::IgStoriesImage")
     expect(media.all?).to eq(true)
   end
 

--- a/spec/uv_media_validator_ig_spec.rb
+++ b/spec/uv_media_validator_ig_spec.rb
@@ -322,4 +322,174 @@ RSpec.describe 'Instagram' do
       expect(media.video_bitrate?).to eq(true)
     end
   end
+
+  describe "Stories" do
+    describe "Image" do
+      it "ig image valid aspect ratio (1 : 2) and wrong format" do
+        media = UvMediaValidator::IgStoriesImage.new("test/ig_images/100x200.gif")
+        expect(media.file_size?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(false)
+      end
+
+      it "ig image valid aspect ratio (2 : 1) and wrong format" do
+        media = UvMediaValidator::IgStoriesImage.new("test/ig_images/200x100.tif")
+        expect(media.file_size?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(false)
+      end
+
+      it "ig image valid aspect ratio (4 : 5) and wrong format" do
+        media = UvMediaValidator::IgStoriesImage.new("test/ig_images/1440x1800.png")
+        expect(media.file_size?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(false)
+      end
+
+      it "ig image valid aspect ratio (1.91 : 1)" do
+        media = UvMediaValidator::IgStoriesImage.new("test/ig_images/1440x754.jpeg")
+        expect(media.file_size?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+
+        media = UvMediaValidator::IgStoriesImage.new("test/ig_images/722x376.jpg") # 1.9202 : 1
+        expect(media.file_size?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+      end
+
+      it "ig image too big" do
+        media = UvMediaValidator::IgStoriesImage.new("test/ig_images/2000x2000.jpeg")
+        expect(media.file_size?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+      end
+    end
+
+    describe "Video" do
+      it "ig video short duration" do
+        media = UvMediaValidator::IgStoriesVideo.new("test/ig_videos/1.8s.mp4")
+        expect(media.file_size?).to eq(true)
+        expect(media.duration?).to eq(false)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+        expect(media.frame_rate_range?).to eq(true)
+        expect(media.audio_codec?).to eq(true)
+        expect(media.audio_sample_rate?).to eq(true)
+        expect(media.audio_channels?).to eq(true)
+        expect(media.video_codec?).to eq(true)
+        expect(media.video_bitrate?).to eq(true)
+      end
+
+      it "ig video normal duration" do
+        media = UvMediaValidator::IgStoriesVideo.new("test/ig_videos/78s.mp4")
+        expect(media.file_size?).to eq(true)
+        expect(media.duration?).to eq(false)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+        expect(media.frame_rate_range?).to eq(true)
+        expect(media.audio_codec?).to eq(true)
+        expect(media.audio_sample_rate?).to eq(true)
+        expect(media.audio_channels?).to eq(true)
+        expect(media.video_codec?).to eq(true)
+        expect(media.video_bitrate?).to eq(true)
+      end
+
+      it "ig video less fps" do
+        media = UvMediaValidator::IgStoriesVideo.new("test/ig_videos/15fps.mp4")
+        expect(media.file_size?).to eq(true)
+        expect(media.duration?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+        expect(media.frame_rate_range?).to eq(false)
+        expect(media.audio_codec?).to eq(true)
+        expect(media.audio_sample_rate?).to eq(true)
+        expect(media.audio_channels?).to eq(true)
+        expect(media.video_codec?).to eq(true)
+        expect(media.video_bitrate?).to eq(true)
+      end
+
+      it "ig video valid aspect ratio (1 : 2)" do
+        media = UvMediaValidator::IgStoriesVideo.new("test/ig_videos/200x400.mp4")
+        expect(media.file_size?).to eq(true)
+        expect(media.duration?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+        expect(media.frame_rate_range?).to eq(true)
+        expect(media.audio_codec?).to eq(true)
+        expect(media.audio_sample_rate?).to eq(true)
+        expect(media.audio_channels?).to eq(true)
+        expect(media.video_codec?).to eq(true)
+        expect(media.video_bitrate?).to eq(true)
+      end
+
+      it "ig video valid aspect ratio (2 : 1)" do
+        media = UvMediaValidator::IgStoriesVideo.new("test/ig_videos/400x200.mp4")
+        expect(media.file_size?).to eq(true)
+        expect(media.duration?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+        expect(media.frame_rate_range?).to eq(true)
+        expect(media.audio_codec?).to eq(true)
+        expect(media.audio_sample_rate?).to eq(true)
+        expect(media.audio_channels?).to eq(true)
+        expect(media.video_codec?).to eq(true)
+        expect(media.video_bitrate?).to eq(true)
+      end
+
+      it "ig video too high spec" do
+        media = UvMediaValidator::IgStoriesVideo.new("test/ig_videos/8K-120fps-96kHz-6channels.mp4")
+        expect(media.file_size?).to eq(true)
+        expect(media.duration?).to eq(true)
+        expect(media.max_height?).to eq(false)
+        expect(media.max_width?).to eq(false)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+        expect(media.frame_rate_range?).to eq(false)
+        expect(media.audio_codec?).to eq(true)
+        expect(media.audio_sample_rate?).to eq(false)
+        expect(media.audio_channels?).to eq(false)
+        expect(media.video_codec?).to eq(true)
+        expect(media.video_bitrate?).to eq(true)
+      end
+
+      it "ig video high bitrate" do
+        media = UvMediaValidator::IgStoriesVideo.new("test/ig_videos/8Mbps_1920x1080.mp4")
+        expect(media.file_size?).to eq(true)
+        expect(media.duration?).to eq(true)
+        expect(media.max_height?).to eq(true)
+        expect(media.max_width?).to eq(true)
+        expect(media.aspect_ratio?).to eq(true)
+        expect(media.format?).to eq(true)
+        expect(media.frame_rate_range?).to eq(true)
+        expect(media.audio_codec?).to eq(true)
+        expect(media.audio_sample_rate?).to eq(true)
+        expect(media.audio_channels?).to eq(true)
+        expect(media.video_codec?).to eq(true)
+        expect(media.video_bitrate?).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instagramストーリーズに関するクラスを追加しました。また、それにあたりInstagramのクラスの種類が増えて `get_ig_validator` メソッドの分岐が複雑になってしまうため、メディア種別(feed, reel, stories)ごとにメソッドを分割しました。