### PR TITLE
fix to be enable changing handling picture's format about the Pinterest.

### DIFF
--- a/lib/uv_media_validator.rb
+++ b/lib/uv_media_validator.rb
@@ -81,9 +81,9 @@ module UvMediaValidator
     IgStoriesVideo.new(path, sync_flag: sync_flag, info: movie)
   end
 
-  def self.get_pin_validator(path)
+  def self.get_pin_validator(path, format: nil)
     image_size = ImageSize.path(path)
-    return PinImage.new(path, info: image_size) unless image_size.format.nil?
+    return PinImage.new(path, info: image_size, format:) unless image_size.format.nil?
 
     movie = FFMPEG::Movie.new(path)
     return nil unless movie.valid?

--- a/lib/uv_media_validator/pin_image.rb
+++ b/lib/uv_media_validator/pin_image.rb
@@ -13,9 +13,10 @@ module UvMediaValidator
     MIN_HEIGHT = 300
     MAX_HEIGHT = 9900
 
-    def initialize(path, info: nil)
+    def initialize(path, info: nil, format: nil)
       @path = path
       @image_size = info
+      @format = format.nil? ? FORMAT_ARRAY : format
     end
 
     def max_width
@@ -55,7 +56,7 @@ module UvMediaValidator
     end
 
     def format?
-      FORMAT_ARRAY.include?(image_size.format)
+      @format.include?(image_size.format)
     end
 
     def all?


### PR DESCRIPTION
Pinterestの場合、通常の画像投稿の際に許されている画像と、サムネイルで許されている画像が異なります。任意に種類を変更したいので、この修正を行いました。

よろしくお願いします。