### PR TITLE
IG_REELのメディアの最大サイズを設定できるようにする

### DIFF
--- a/lib/uv_media_validator.rb
+++ b/lib/uv_media_validator.rb
@@ -59,7 +59,7 @@ module UvMediaValidator
     IgVideo.new(path, sync_flag: sync_flag, info: movie)
   end
 
-  def self.get_ig_reel_validator(path, sync_flag: true)
+  def self.get_ig_reel_validator(path, sync_flag: true, max_bytes: nil)
     image_size = ImageSize.path(path)
 
     # リールは動画のみ
@@ -68,7 +68,7 @@ module UvMediaValidator
     movie = FFMPEG::Movie.new(path)
     return nil unless movie.valid?
 
-    IgReel.new(path, sync_flag: sync_flag, info: movie)
+    IgReel.new(path, sync_flag: sync_flag, info: movie, max_bytes: max_bytes)
   end
 
   def self.get_ig_stories_validator(path, sync_flag: true, max_image_bytes: nil)

--- a/lib/uv_media_validator/ig_video.rb
+++ b/lib/uv_media_validator/ig_video.rb
@@ -126,7 +126,16 @@ module UvMediaValidator
     MAX_ASPECT_RATIO = 10.fdiv(1)
     MAX_DURATION = 60 * 15
     MIN_DURATION = 3
-    MAX_SIZE = 1024 * 1024 * 1024 # Bytes
+    MAX_SIZE = 1024 * 1024 * 1024 # Bytes (default: 1GB)
+
+    def initialize(path, sync_flag: true, info: nil, max_bytes: nil)
+      super(path, sync_flag: sync_flag, info: info)
+      @max_bytes = max_bytes
+    end
+
+    def max_size
+      @max_bytes || self.class::MAX_SIZE
+    end
   end
 
   # For Instagram stories video

--- a/spec/uv_media_validator_ig_spec.rb
+++ b/spec/uv_media_validator_ig_spec.rb
@@ -378,6 +378,14 @@ RSpec.describe 'Instagram' do
       expect(media.video_codec?).to eq(true)
       expect(media.video_bitrate?).to eq(true)
     end
+
+    it 'ig reel with custom max_bytes' do
+      media_default = UvMediaValidator::IgReel.new('test/ig_videos/30fps_44100Hz_640x480.mp4')
+      expect(media_default.max_size).to eq(1024 * 1024 * 1024)
+
+      media_custom = UvMediaValidator::IgReel.new('test/ig_videos/30fps_44100Hz_640x480.mp4', max_bytes: 300 * 1024 * 1024)
+      expect(media_custom.max_size).to eq(300 * 1024 * 1024)
+    end
   end
 
   describe 'Stories' do


### PR DESCRIPTION
[IGのドキュメント](https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media/#:~:text=%E6%9C%80%E5%B0%8F3%E7%A7%92-,%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%B5%E3%82%A4%E3%82%BA%3A%20%E6%9C%80%E5%A4%A7300MB,-%E3%83%AA%E3%83%BC%E3%83%AB%E3%81%AE%E3%82%AB%E3%83%90%E3%83%BC)より、REEL投稿の最大サイズを300mbに設定できるようにした。

設定値を300mbに修正しても良かったが、API経由でも300mb以上の動画をアップロードできる状態であることと、他の影響範囲が分からないので、デフォルトは1024mbそのままで、引数でもらったサイズで最大サイズを設定できるようにした。